### PR TITLE
Update socket name for 2.6.0 and later

### DIFF
--- a/keepassxc.el
+++ b/keepassxc.el
@@ -134,7 +134,7 @@
 
 ;;; Socket interface
 
-(defvar keepassxc--socket-name "kpxc_server"
+(defvar keepassxc--socket-name "org.keepassxc.KeePassXC.BrowserServer"
   "Filename of the KeePassXC unix domain socket.")
 (defvar keepassxc--process-name " *keepassxc-socket-process*")
 (defvar keepassxc--keypair nil)


### PR DESCRIPTION
The name of the socket keepassxc uses has changed (See https://github.com/keepassxreboot/keepassxc/commit/2237cf0188af38898e1492f5d7ce2c0f087c8f35)

